### PR TITLE
Fixed bug with resolver threads causing the resolver to wait 60 seconds ...

### DIFF
--- a/rio-resolver/resolver-aether/src/main/java/org/rioproject/resolver/aether/AetherResolver.java
+++ b/rio-resolver/resolver-aether/src/main/java/org/rioproject/resolver/aether/AetherResolver.java
@@ -42,11 +42,18 @@ import java.util.concurrent.atomic.AtomicInteger;
 public class AetherResolver implements Resolver {
     protected AetherService service;
     private final Map<ResolutionRequest, Future<String[]>> resolvingMap = new ConcurrentHashMap<ResolutionRequest, Future<String[]>>();
-    private final ExecutorService resolverExecutor = Executors.newCachedThreadPool();
+    private ExecutorService resolverExecutor;
     private final List<RemoteRepository> cachedRemoteRepositories = new ArrayList<RemoteRepository>();
     private static final Logger logger = LoggerFactory.getLogger(AetherResolver.class.getName());
 
     public AetherResolver() {
+        resolverExecutor = Executors.newScheduledThreadPool(1, new ThreadFactory() {
+            @Override public Thread newThread(Runnable runnable) {
+                Thread thread = Executors.defaultThreadFactory().newThread(runnable);
+                thread.setDaemon(true);
+                return thread;
+            }
+        });
         service = AetherService.getDefaultInstance();
     }
 


### PR DESCRIPTION
...after being used and keeping the client unnecessarily alive. Threads switched to daemons.
