### PR TITLE
add backslash character to Artifact regex; test

### DIFF
--- a/rio-resolver/resolver-api/src/main/java/org/rioproject/resolver/Artifact.java
+++ b/rio-resolver/resolver-api/src/main/java/org/rioproject/resolver/Artifact.java
@@ -51,7 +51,7 @@ public class Artifact {
     public Artifact(String artifact) {
         if(artifact==null)
             throw new IllegalArgumentException("artifact is null");
-        Pattern p = Pattern.compile("([^: /]+):([^: /]+)(:([^: /]*)(:([^: /]+))?)?:([^: /]+)" );
+        Pattern p = Pattern.compile("([^: /\\\\]+):([^: /\\\\]+)(:([^: /\\\\]*)(:([^: /\\\\]+))?)?:([^: /\\\\]+)" );
         Matcher m = p.matcher( artifact );
         if (!m.matches() ) {
             throw new IllegalArgumentException( "Bad artifact coordinates " + artifact

--- a/rio-resolver/resolver-api/src/test/java/org/rioproject/resolver/maven2/ArtifactCreationTest.java
+++ b/rio-resolver/resolver-api/src/test/java/org/rioproject/resolver/maven2/ArtifactCreationTest.java
@@ -33,6 +33,11 @@ public class ArtifactCreationTest {
         new Artifact("org/foo.foo:bar:2.0");
     }
 
+    @Test(expected = IllegalArgumentException.class)
+    public void createBadArtifact3() throws Exception {
+        new Artifact("C:\\dir\\file.jar;C:\\dir\\file2.jar");
+    }
+
     @Test
     public void createGoodArtifact() {
         Artifact a = new Artifact("org.foo:bar:2.0");


### PR DESCRIPTION
new Artifact() called with two or more absolute windows paths (C:\file1;C:\file2) is accepted because of colons separating drive and path. This change adds \ to negative matches.

Perhaps the regex checking for artifacts should consist of positive matches, e.g. [\w\d-] or [\p{L}\d-]
