### PR TITLE
fix CLI bug on EOF

### DIFF
--- a/rio-tools/rio-cli/src/main/java/org/rioproject/tools/cli/CLI.java
+++ b/rio-tools/rio-cli/src/main/java/org/rioproject/tools/cli/CLI.java
@@ -422,7 +422,10 @@ public class CLI {
         while (true) {
             try {
                 String input = br.readLine();
-                if(input != null && input.length()>0) {
+                if (input == null)
+                    //end of stream
+                    input = "exit";
+                if (input.length() > 0) {
                     if(input.equals("q") || input.equals("quit") || input.equals("exit")) {
                         try {
                             br.close();


### PR DESCRIPTION
this fix makes rio shell to treat EOF or ctrl+d as exit command
