### PR TITLE
RemoteEvent compatibility with River 3.0

### DIFF
--- a/rio-core/rio-api/src/main/java/org/rioproject/event/RemoteServiceEvent.java
+++ b/rio-core/rio-api/src/main/java/org/rioproject/event/RemoteServiceEvent.java
@@ -15,11 +15,14 @@
  */
 package org.rioproject.event;
 
-import net.jini.core.event.RemoteEvent;
-
+import java.io.IOException;
+import java.io.ObjectInputStream;
 import java.io.Serializable;
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
 import java.rmi.MarshalledObject;
 import java.util.Date;
+import net.jini.core.event.RemoteEvent;
 
 /**
  * Wrapper around <code>RemoteEvent</code> to allow user defined event objects. 
@@ -35,8 +38,89 @@ import java.util.Date;
  */
 public class RemoteServiceEvent extends RemoteEvent implements Serializable {
     static final long serialVersionUID = 1L;
-    /** The time this event was fired */
+    
+    /* Support for versions prior to River 3.0.0
+     * Set superclass fields in versions of River before 3.0.0, so
+     * the current state of those fields is serialized.  River 3.0.0 does
+     * this automatically for us, by calling getter methods during writeObject.
+     */
+    static final boolean REMOTE_EVENT_CLASS_CHANGED;
+    static final Field EVENT_ID;
+    static final Field SEQ_NUM;
+    static final Field HANDBACK;
+    
+    static { //May throw a security exception
+	boolean classChange;
+	Field event_id = null;
+	Field seq_num = null;
+	Field hand_back = null;
+	try {
+	    event_id = RemoteEvent.class.getDeclaredField("eventID");
+	    int modifier = event_id.getModifiers();
+	    if (modifier == Modifier.PROTECTED){
+		classChange = false;
+		seq_num = RemoteEvent.class.getDeclaredField("seqNum");
+		hand_back = RemoteEvent.class.getDeclaredField("handback");
+	    } else {
+		classChange = true;
+	    }
+	} catch (NoSuchFieldException ex) {
+	    classChange = false;
+	} 
+	REMOTE_EVENT_CLASS_CHANGED = classChange;
+	if (!classChange){
+	    EVENT_ID = event_id;
+	    SEQ_NUM = seq_num;
+	    HANDBACK = hand_back;
+	} else {
+	    EVENT_ID = null;
+	    SEQ_NUM = null;
+	    HANDBACK = null;
+	}
+    }
+    
+    private static void setField (Field f, Object caller, long value){
+	// Support for River / Jini < 3.0.0, remove when no longer required
+	if (!REMOTE_EVENT_CLASS_CHANGED){
+	    try {
+		f.setLong(caller, value);
+	    } catch (IllegalArgumentException ex) {
+		throw new AssertionError("This shouldn't happen", ex);
+	    } catch (IllegalAccessException ex) {
+		throw new AssertionError(
+		    "This class should have access to protected method in superclass",
+		    ex
+		);
+	    }
+	}
+    }
+    
+    private static void setField (Field f, Object caller, Object value){
+	// Support for River / Jini < 3.0.0, remove when no longer required
+	if (!REMOTE_EVENT_CLASS_CHANGED){
+	    try {
+		f.set(caller, value);
+	    } catch (IllegalArgumentException ex) {
+		throw new AssertionError("This shouldn't happen", ex);
+	    } catch (IllegalAccessException ex) {
+		throw new AssertionError(
+		    "This class should have access to protected method in superclass",
+		    ex
+		);
+	    }
+	}
+    }
+    
+    /** The time this event was fired 
+     * @serial
+     */
     private final Date date;
+    /** Private transient state for compatibility with River 3.0 RemoteEvent
+     *  which is immutable.
+     */
+    private transient long eventID;
+    private transient long seqNum;
+    private transient MarshalledObject handback;
 
     /**
      * Create a new <code>RemoteServiceEvent</code>. This creates
@@ -55,6 +139,12 @@ public class RemoteServiceEvent extends RemoteEvent implements Serializable {
         super(source, 0, 0, null);
         date = new Date(System.currentTimeMillis());
     }
+    
+    //Inherit javadoc
+    @Override
+    public long getID(){
+	return eventID;
+    }
 
     /**
      * Set the eventID
@@ -62,7 +152,14 @@ public class RemoteServiceEvent extends RemoteEvent implements Serializable {
      * @param eventID The eventID for the RemoteEvent
      */
     public void setEventID(long eventID) {
-        super.eventID = eventID;
+        this.eventID = eventID;
+	setField(EVENT_ID, this, eventID);
+    }
+    
+    //Inherit javadoc
+    @Override
+    public long getSequenceNumber(){
+	return seqNum;
     }
 
     /**
@@ -71,7 +168,14 @@ public class RemoteServiceEvent extends RemoteEvent implements Serializable {
      * @param seqNum The sequence number of the RemoteEvent
      */
     public void setSequenceNumber(long seqNum) {
-        super.seqNum = seqNum;
+        this.seqNum = seqNum;
+	setField(SEQ_NUM, this, seqNum);
+    }
+    
+    //Inherit javadoc
+    @Override
+    public MarshalledObject getRegistrationObject() {
+	return handback;
     }
 
     /**
@@ -81,7 +185,8 @@ public class RemoteServiceEvent extends RemoteEvent implements Serializable {
      * for the RemoteEvent
      */
     public void setHandback(MarshalledObject handback) {
-        super.handback = handback;
+        this.handback = handback;
+	setField(HANDBACK, this, handback);
     }
 
     /**
@@ -91,6 +196,18 @@ public class RemoteServiceEvent extends RemoteEvent implements Serializable {
      */
     public Date getDate(){
         return(date);
+    }
+    
+    private void readObject(ObjectInputStream in) 
+	    throws ClassNotFoundException, IOException
+    {
+	/* From River 3.0.0, RemoteEvent's writeObject method calls the getter
+	 * methods overridden by this instance.
+	 */
+	in.defaultReadObject();
+	eventID = super.getID();
+	seqNum = super.getSequenceNumber();
+	handback = super.getRegistrationObject();
     }
 }
 

--- a/rio-core/rio-api/src/main/java/org/rioproject/event/RemoteServiceEvent.java
+++ b/rio-core/rio-api/src/main/java/org/rioproject/event/RemoteServiceEvent.java
@@ -39,77 +39,86 @@ import net.jini.core.event.RemoteEvent;
 public class RemoteServiceEvent extends RemoteEvent implements Serializable {
     static final long serialVersionUID = 1L;
     
-    /* Support for versions prior to River 3.0.0
-     * Set superclass fields in versions of River before 3.0.0, so
-     * the current state of those fields is serialized.  River 3.0.0 does
+    /* Support for versions prior to River 3.0.0:
+     * Sets superclass fields in versions of River before 3.0.0, so
+     * current state of those fields is serialized.  River 3.0.0 does
      * this automatically for us, by calling getter methods during writeObject.
+     * 
+     * Presently, due to the com.sun.jini to org.apache.river namespace change
+     * it isn't possible for Rio to support both versions of River either
+     * side of this change, so most of the code is commented out.
+     * 
+     * If Rio is restructured slightly, such that a new module is created,
+     * that depends on com.sun.jini OR org.apache.river namspaces and 
+     * content exported to Rio API, then Rio could support versions either side
+     * of the namespace change.  In that case uncomment the code.
      */
-    static final boolean REMOTE_EVENT_CLASS_CHANGED;
-    static final Field EVENT_ID;
-    static final Field SEQ_NUM;
-    static final Field HANDBACK;
-    
-    static { //May throw a security exception
-	boolean classChange;
-	Field event_id = null;
-	Field seq_num = null;
-	Field hand_back = null;
-	try {
-	    event_id = RemoteEvent.class.getDeclaredField("eventID");
-	    int modifier = event_id.getModifiers();
-	    if (modifier == Modifier.PROTECTED){
-		classChange = false;
-		seq_num = RemoteEvent.class.getDeclaredField("seqNum");
-		hand_back = RemoteEvent.class.getDeclaredField("handback");
-	    } else {
-		classChange = true;
-	    }
-	} catch (NoSuchFieldException ex) {
-	    classChange = false;
-	} 
-	REMOTE_EVENT_CLASS_CHANGED = classChange;
-	if (!classChange){
-	    EVENT_ID = event_id;
-	    SEQ_NUM = seq_num;
-	    HANDBACK = hand_back;
-	} else {
-	    EVENT_ID = null;
-	    SEQ_NUM = null;
-	    HANDBACK = null;
-	}
-    }
-    
-    private static void setField (Field f, Object caller, long value){
-	// Support for River / Jini < 3.0.0, remove when no longer required
-	if (!REMOTE_EVENT_CLASS_CHANGED){
-	    try {
-		f.setLong(caller, value);
-	    } catch (IllegalArgumentException ex) {
-		throw new AssertionError("This shouldn't happen", ex);
-	    } catch (IllegalAccessException ex) {
-		throw new AssertionError(
-		    "This class should have access to protected method in superclass",
-		    ex
-		);
-	    }
-	}
-    }
-    
-    private static void setField (Field f, Object caller, Object value){
-	// Support for River / Jini < 3.0.0, remove when no longer required
-	if (!REMOTE_EVENT_CLASS_CHANGED){
-	    try {
-		f.set(caller, value);
-	    } catch (IllegalArgumentException ex) {
-		throw new AssertionError("This shouldn't happen", ex);
-	    } catch (IllegalAccessException ex) {
-		throw new AssertionError(
-		    "This class should have access to protected method in superclass",
-		    ex
-		);
-	    }
-	}
-    }
+//    static final boolean REMOTE_EVENT_CLASS_CHANGED;
+//    static final Field EVENT_ID;
+//    static final Field SEQ_NUM;
+//    static final Field HANDBACK;
+//    
+//    static { //May throw a security exception
+//	boolean classChange;
+//	Field event_id = null;
+//	Field seq_num = null;
+//	Field hand_back = null;
+//	try {
+//	    event_id = RemoteEvent.class.getDeclaredField("eventID");
+//	    int modifier = event_id.getModifiers();
+//	    if (modifier == Modifier.PROTECTED){
+//		classChange = false;
+//		seq_num = RemoteEvent.class.getDeclaredField("seqNum");
+//		hand_back = RemoteEvent.class.getDeclaredField("handback");
+//	    } else {
+//		classChange = true;
+//	    }
+//	} catch (NoSuchFieldException ex) {
+//	    classChange = false;
+//	} 
+//	REMOTE_EVENT_CLASS_CHANGED = classChange;
+//	if (!classChange){
+//	    EVENT_ID = event_id;
+//	    SEQ_NUM = seq_num;
+//	    HANDBACK = hand_back;
+//	} else {
+//	    EVENT_ID = null;
+//	    SEQ_NUM = null;
+//	    HANDBACK = null;
+//	}
+//    }
+//    
+//    private static void setField (Field f, Object caller, long value){
+//	// Support for River / Jini < 3.0.0, remove when no longer required
+//	if (!REMOTE_EVENT_CLASS_CHANGED){
+//	    try {
+//		f.setLong(caller, value);
+//	    } catch (IllegalArgumentException ex) {
+//		throw new AssertionError("This shouldn't happen", ex);
+//	    } catch (IllegalAccessException ex) {
+//		throw new AssertionError(
+//		    "This class should have access to protected method in superclass",
+//		    ex
+//		);
+//	    }
+//	}
+//    }
+//    
+//    private static void setField (Field f, Object caller, Object value){
+//	// Support for River / Jini < 3.0.0, remove when no longer required
+//	if (!REMOTE_EVENT_CLASS_CHANGED){
+//	    try {
+//		f.set(caller, value);
+//	    } catch (IllegalArgumentException ex) {
+//		throw new AssertionError("This shouldn't happen", ex);
+//	    } catch (IllegalAccessException ex) {
+//		throw new AssertionError(
+//		    "This class should have access to protected method in superclass",
+//		    ex
+//		);
+//	    }
+//	}
+//    }
     
     /** The time this event was fired 
      * @serial
@@ -153,7 +162,7 @@ public class RemoteServiceEvent extends RemoteEvent implements Serializable {
      */
     public void setEventID(long eventID) {
         this.eventID = eventID;
-	setField(EVENT_ID, this, eventID);
+//	setField(EVENT_ID, this, eventID);
     }
     
     //Inherit javadoc
@@ -169,7 +178,7 @@ public class RemoteServiceEvent extends RemoteEvent implements Serializable {
      */
     public void setSequenceNumber(long seqNum) {
         this.seqNum = seqNum;
-	setField(SEQ_NUM, this, seqNum);
+//	setField(SEQ_NUM, this, seqNum);
     }
     
     //Inherit javadoc
@@ -186,7 +195,7 @@ public class RemoteServiceEvent extends RemoteEvent implements Serializable {
      */
     public void setHandback(MarshalledObject handback) {
         this.handback = handback;
-	setField(HANDBACK, this, handback);
+//	setField(HANDBACK, this, handback);
     }
 
     /**


### PR DESCRIPTION
Dennis,

This doesn't include the River 3.0 com.sun.jini to org.apache.river name space changes, only changes to net.jini.core.event.RemoteEvent which may end up being rolled back, depending on the outcome of a new discussion, these change would update RemoteServiceEvent to be compatible with River 3.0.

Regards,

Peter.